### PR TITLE
Allow using OR on empty scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ This would let you write handy things like
     to_harass    = Blog.joins(:author).where('authors.name' => 'Julian')\
                                       .or.generally_disliked
 
+Also, if you call `or` on a condition-less scope, it will be ignored:
+
+    Blog.scoped.or.where(:name => 'Julian')
+
+This means you can start off the query with an `or`, in case you don't
+know the state of the scope.
+
 The end.
 
 Credits

--- a/lib/active_record_or.rb
+++ b/lib/active_record_or.rb
@@ -7,8 +7,12 @@ module ActiveRecordOr
     end
 
     def method_missing(method, *args, &block)
+      last_left_constraint = @left.constraints.last
+      return @left.send(method, *args, &block) unless last_left_constraint
+
       raw_right = @left.unscoped.send(method, *args, &block)
-      or_based_constraints = @left.constraints.last.or(raw_right.constraints.last)
+
+      or_based_constraints = last_left_constraint.or(raw_right.constraints.last)
       right = @left.send(method, *args, &block)
       right.where_values = [or_based_constraints]
       right

--- a/test/active_record_or_test.rb
+++ b/test/active_record_or_test.rb
@@ -48,5 +48,11 @@ describe ActiveRecord::Relation do
       to_harass.join_sql.must_equal(
        %(INNER JOIN "authors" ON "authors"."id" = "blogs"."author_id") )
     end
+
+    it "works with no conditions on the left side" do
+      sql = Blog.scoped.or.where(:name => 'Julian')
+
+      sql.to_sql.must_equal "SELECT \"blogs\".* FROM \"blogs\"  WHERE \"blogs\".\"name\" = 'Julian'"
+    end
   end
 end


### PR DESCRIPTION
This pull request adds support for using `or` on scopes with no conditions.

e.g. Blog.scoped.or.where(:name => "some name")

This is useful when you are building a query through a query builder, and you don't know the initial state of the arel object.
